### PR TITLE
Fixed a bug that caused an exception when changing clothes.

### DIFF
--- a/AdvIKPlugin/AdvIKCharaController.cs
+++ b/AdvIKPlugin/AdvIKCharaController.cs
@@ -411,7 +411,8 @@ namespace AdvIKPlugin
                 if (AdvIKPlugin.EnableResizeOnFolder.Value)
                 {
                     OCIChar me = StudioObjectExtensions.GetOCIChar(ChaControl);
-                    RecurseForName(me.treeNodeObject);                    
+                    if(me != null)
+                        RecurseForName(me.treeNodeObject);                    
                 }
                 yield return new WaitForSeconds(5);
             }


### PR DESCRIPTION
Fixed a bug that caused an exception when performing certain operations when changing clothes in the studio.
Please merge if there is no problem.

Reproduction procedure:
1. Launch Studio
2. Load any character
3. Open the Load Costume menu
4. Click [Show Selection]
5. Click on Switch Costumes
![スクリーンショット 2023-12-01 221709](https://github.com/OrangeSpork/AdvIKPlugin/assets/4230203/e904558b-c086-4f90-9a09-5b0a43018bde)

Log:
```
NullReferenceException: Object reference not set to an instance of an object
  at AdvIKPlugin.AdvIKCharaController+<ScanForFlagCo>d__76.MoveNext () [0x00000] in <filename unknown>:0 
  at UnityEngine.SetupCoroutine.InvokeMoveNext (IEnumerator enumerator, IntPtr returnValueAddress) [0x00000] in <filename unknown>:0 
 ```
[kk_output_log.txt](https://github.com/OrangeSpork/AdvIKPlugin/files/13529811/kk_output_log.txt)
[kks_output_log.txt](https://github.com/OrangeSpork/AdvIKPlugin/files/13529812/kks_output_log.txt)

This problem occurs in both KK and KKS.
As part of the clothing change process, the character reloads. It seems that GetOCIChar() does not work correctly in the frame immediately after reloading.
